### PR TITLE
add chromium flags to allow JS access to local FS

### DIFF
--- a/recipes-browser/chromium/chromium-ozone-wayland_%.bbappend
+++ b/recipes-browser/chromium/chromium-ozone-wayland_%.bbappend
@@ -1,4 +1,4 @@
 # Add Kiosk mode enabled by default with special commands args.
 PACKAGECONFIG += "kiosk-mode"
 #TODO: create a user for running chromium and remove the --no-sandbox argument.
-CHROMIUM_EXTRA_ARGS_append = " --in-process-gpu --incognito --no-first-run --no-sandbox"
+CHROMIUM_EXTRA_ARGS_append = " --in-process-gpu --incognito --no-first-run --no-sandbox --disable-web-security --user-data-dir=~/.chromium"


### PR DESCRIPTION
Required for running angular apps from the local filesystem without hosting them with a HTTP server.